### PR TITLE
Fix unzip on windows (fixes issue #16)

### DIFF
--- a/src/windows/FiNeZeep/FiNeZeep.cs
+++ b/src/windows/FiNeZeep/FiNeZeep.cs
@@ -103,9 +103,7 @@ namespace FiNeZeep
 						using (Stream fileStream = await file.OpenStreamForWriteAsync())
 						using (Stream entryStream = entry.Open())
 						{
-							byte[] buffer = new byte[entry.Length];
-							await entryStream.ReadAsync(buffer, 0, buffer.Length);
-							await fileStream.WriteAsync(buffer, 0, buffer.Length);
+							await entryStream.CopyToAsync(fileStream);
 							await fileStream.FlushAsync();
 						}
 					}


### PR DESCRIPTION
Fixes unzip on windows platform.

Related issue: https://github.com/FortuneN/cordova-plugin-zeep/issues/16

No more NULL data in the output !